### PR TITLE
[O] Optimize getModule return type

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/module/ModuleManager.java
+++ b/src/main/java/me/zeroeightsix/kami/module/ModuleManager.java
@@ -120,6 +120,17 @@ public class ModuleManager {
     }
 
     /**
+     * Get typed module object so that no casting is needed afterwards.
+     *
+     * @param clazz Module class
+     * @param <T> Type of module
+     * @return Object
+     */
+    public <T extends Module> T getModuleT(Class<T> clazz) {
+        return (T) modules.get(clazz);
+    }
+
+    /**
      * @deprecated Use `getModule(Class<? extends Module>)` instead
      */
     @Deprecated


### PR DESCRIPTION
* Created a `T getModuleT(Class<T>)` method so that no casting is needed after getting module.